### PR TITLE
[all] Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.5.0 (2019-07-09)
 
 - **[Breaking change]** Update to `avm1-tree@0.5`.
 - **[Internal]** Switch to `travis-ci.com` for CI.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "avm1-parser"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "avm1-tree 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm1-parser"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "AVM1 parser"
 documentation = "https://github.com/open-flash/avm1-parser"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avm1-parser",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "AVM1 parser",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Breaking change]** Update to `avm1-tree@0.5`.
- **[Internal]** Switch to `travis-ci.com` for CI.

## Rust

- **[Internal]** Add `rustfmt` support.