### PR TITLE
[all] Release v0.9.0

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "avm1-parser"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "avm1-types 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm1-parser"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "AVM1 parser"
 documentation = "https://github.com/open-flash/avm1-parser"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avm1-parser",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "AVM1 parser",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Breaking change]** Update to `avm1-types@0.9` (former `avm1-tree`).