### PR TITLE
[all] Add support for fall-through over empty blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- **[Fix]** Add support for fall-through over empty blocks (especially over empty but defined `finally`).
+
 # 0.9.0 (2019-09-27)
 
 - **[Breaking change]** Update to `avm1-types@0.9` (former `avm1-tree`).

--- a/ts/src/lib/cfg-from-bytes.ts
+++ b/ts/src/lib/cfg-from-bytes.ts
@@ -212,9 +212,6 @@ function resolveLabels(
   }
 
   const offsetToLabel: Map<UintSize, NullableCfgLabel> = new Map();
-  if (soft.actions.has(soft.start)) {
-    offsetToLabel.set(soft.start, toLabel(soft.start));
-  }
   for (const offset of soft.actions.keys()) {
     if (soft.jumpTargets.has(offset) || soft.simpleTargets.get(offset) !== 1) {
       offsetToLabel.set(offset, toLabel(offset));
@@ -243,6 +240,7 @@ function resolveLabels(
       offsetToLabel.set(outJump, parentLabel);
     }
   }
+  offsetToLabel.set(soft.start, toLabel(soft.start));
   const sortedResult: Map<UintSize, string | null> = new Map();
   const sortedOffsets: UintSize[] = [...offsetToLabel.keys()];
   sortedOffsets.sort((a, b) => a - b);
@@ -438,9 +436,13 @@ function buildCfg(
     if (defaultNext === undefined) {
       throw new Error("AssertionError: Empty CFG without known `defaultNext`");
     }
+    const label: NullableCfgLabel | undefined = labels.get(soft.start);
+    if (label === null || label === undefined) {
+      throw new Error("AssertionError: Expected empty block start label to have an id`");
+    }
     const head: CfgSimpleBlock = {
       type: CfgBlockType.Simple,
-      label: `l${soft.id}`,
+      label,
       actions: [],
       next: defaultNext,
     };


### PR DESCRIPTION
This commit fixes an edge case around empty blocks where a `try` or `catch` block could fall-through and skip an empty (but defined) `finally`. As part of the fix, it also adds offset to empty block labels (so all labels are computed the same way).