### PR TITLE
[ts] Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Next
+# 0.9.1 (2019-09-28)
+
+## Typescript
 
 - **[Fix]** Add support for fall-through over empty blocks (especially over empty but defined `finally`).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Build status](https://img.shields.io/travis/com/open-flash/avm1-parser/master.svg)](https://travis-ci.com/open-flash/avm1-parser)
 
 AVM1 parser implemented in Rust and Typescript (Node and browser).
-Converts bytes to [`avm1-tree` control flow graphs][avm1-tree].
+Converts bytes to [`avm1-types` control flow graphs][avm1-types].
 
 - [Rust implementation](./rs/README.md)
 - [Typescript implementation](./ts/README.md)
@@ -42,4 +42,4 @@ You can also use the library and report any issues you encounter on the Github
 issues page.
 
 [ofl]: https://github.com/open-flash/open-flash
-[avm1-tree]: https://github.com/open-flash/avm1-tree
+[avm1-types]: https://github.com/open-flash/avm1-types

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avm1-parser",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AVM1 parser",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
## Typescript

- **[Fix]** Add support for fall-through over empty blocks (especially over empty but defined `finally`).