### PR TITLE
[all] Use DFS order for layer numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+- **[Breaking change]** Use DFS order for layer numbering.
+
 ## Rust
 
 - **[Fix]** Update to `nom@5`.


### PR DESCRIPTION
This commit prepares support for the new CFG parser algorithm. It performs a single pass generating parsed blocks, instead of the current two-step discover-and-build process. This design changes how layers are numbered.

This commit keeps the old algorithm, but tweaks it slightly to produce the same DFS order numbering.