### PR TITLE
[all] Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.11.0 (2020-09-07)
 
 - **[Breaking change]** Update to `avm1-types@0.11.0`.
 

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -8,7 +8,7 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "avm1-parser"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "avm1-types",
  "nom",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm1-parser"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "AVM1 parser"
 documentation = "https://github.com/open-flash/avm1-parser"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avm1-parser",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "AVM1 parser",
   "licenses": [
     {


### PR DESCRIPTION
- **[Breaking change]** Update to `avm1-types@0.11.0`.

## Rust

- **[Internal]** Move binary out of the library crate.

## TypeScript

- **[Breaking change]** Update to native ESM.
- **[Internal]** Switch from `tslint` to `eslint`.