### PR TITLE
[all] Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.12.0 (2021-05-05)
 
 - **[Breaking change]** Update to `avm1-types@0.12.0`.
 - **[Feature]** Add support for the `StrictMode` action.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -14,7 +14,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "avm1-parser"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "avm1-types 0.12.0",
  "nom",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm1-parser"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "AVM1 parser"
 documentation = "https://github.com/open-flash/avm1-parser"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avm1-parser",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "AVM1 parser",
   "licenses": [
     {


### PR DESCRIPTION
- **[Breaking change]** Update to `avm1-types@0.12.0`.
- **[Feature]** Add support for the `StrictMode` action.
- **[Fix]** Fix support for `float64` push value.

## TypeScript

- **[Internal]** Update to Yarn 2.